### PR TITLE
Don't use lo as a placeholder interface for Babeld

### DIFF
--- a/roles/build-config/templates/babeld.j2
+++ b/roles/build-config/templates/babeld.j2
@@ -17,13 +17,8 @@ config interface
         option 'max_rtt_penalty' '1000'
 
 config interface
-        option 'ifname' 'lo'
+        option 'ifname' 'fake_interface'
         option 'hello_interval' '4'
-
-config filter
-        option 'type'   'redistribute'
-        option 'if'     'lo'
-        option 'action' 'deny'
 
 config filter
         option 'type'   'redistribute'


### PR DESCRIPTION
It turns out this causes all sorts of strange behavior which eventually
causes problems in Babeld