### PR TITLE
Migrating config for exits by adjusting rita.toml.j2

### DIFF
--- a/roles/build-config/templates/rita.toml.j2
+++ b/roles/build-config/templates/rita.toml.j2
@@ -32,7 +32,7 @@ registration_port = 4875
 description = "The Althea testing exit cluster. Unstable!"
 state = "New"
 [exit_client.exits.test.id]
-mesh_ip = "fd00::1337:1e0f"
+subnet = "fd00::1337:1e0f/128"
 eth_address = "0x5aee3dff733f56cfe7e5390b9cc3a46a90ca1cfa"
 wg_public_key = "zgAlhyOQy8crB0ewrsWt3ES9SvFguwx5mq9i2KiknmA="
 
@@ -41,7 +41,7 @@ registration_port = 4875
 description = "The Althea Production US exit"
 state = "New"
 [exit_client.exits.us_west.id]
-mesh_ip = "fd00::1337:0e2f"
+subnet = "fd00::1337:0e2f/116"
 eth_address = "0x72d9e579f691d62aa7e0703840db6dd2fa9fae21"
 wg_public_key = "jkIodvXKgij/rAEQXFEPJpls6ooxXJEC5XlWA1uUPUg="
 
@@ -50,7 +50,7 @@ registration_port = 4875
 description = "Althea Africa exit"
 state = "New"
 [exit_client.exits.africa.id]
-mesh_ip = "fd00::1337:0e7f"
+subnet = "fd00::1337:2e2f/116"
 eth_address = "0xEba3aF4E87663b3Bb57FC89976502b960e3906ff"
 wg_public_key = "V0tgdQ2Ljx5xyw4UMQ6a7ZztQmyvqrUp/4jrFcCeG1w="
 
@@ -59,7 +59,7 @@ registration_port = 4875
 description = "Nodo de salida de America del Sur"
 state = "New"
 [exit_client.exits.south_america_eth.id]
-mesh_ip = "fd00::1337:0e8f"
+subnet = "fd00::1337:6e2f/116"
 eth_address = "0x81b6c9f8cfd8f135743a9d39b3b0386024ea4cc8"
 wg_public_key = "AlsMwUkJmiA+EQ45p+n+RAtXq1rCA51k58HRwlzoETs="
 
@@ -68,7 +68,7 @@ registration_port = 4875
 description = "In Singapore"
 state = "New"
 [exit_client.exits.apac.id]
-mesh_ip = "fd00::1337:0e4f"
+subnet = "fd00::1337:4e2f/128"
 eth_address = "0xe4ad1f9aa23957d294d869b70fc8f28774df896e"
 wg_public_key = "1kKSpzdhI4kfqeMqch9I1bXqOUXeKN7EQBecVzW60ys="
 
@@ -77,7 +77,7 @@ registration_port = 4875
 description = "Canada Althea Exit"
 state = "New"
 [exit_client.exits.ca.id]
-mesh_ip = "fd00::1337:3e9f"
+subnet = "fd00::1337:3e9f/128"
 eth_address = "0x90b82ed41dcd867df7d2aedab62280e82fcd64f3"
 wg_public_key = "D0z23bOTn5RQgM87nuxx6zgmFMMAKBHXSOXopHtZhTc="
 
@@ -87,7 +87,7 @@ description = "Puerto Rico Exit"
 state = "New"
 [exit_client.exits.pr.id]
 eth_address = "0x6c806Fea0fE17CCdc90312E5dFe53D69EaFE7762"
-mesh_ip = "fd00::1337:eaf"
+subnet = "fd00::1337:eaf1/128"
 wg_public_key = "2wnoOmOuCwqV6dIjzn0uaALSxhwx+w8XH2neUr5NRUY="
 
 


### PR DESCRIPTION
The config for rita.toml.j2 was adjusted in order to
use the new exits, now that the migration code has been removed from althea_rs